### PR TITLE
npm-bcrypt 0.7.8_2

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
     name         : 'okland:accounts-phone',
-    version      : '0.0.10',
+    version      : '0.0.10_1',
     // Brief, one-line summary of the package.
     summary      : 'A login service based on mobile phone number, For Meteor.',
     // URL to the Git repository containing the source code for this package.
@@ -17,7 +17,7 @@ Npm.depends({
 });
 
 Package.onUse(function (api) {
-    api.use('npm-bcrypt@=0.7.7', 'server');
+    api.use('npm-bcrypt@=0.7.8_2', 'server');
 
     api.use('accounts-base@1.0.2', ['client', 'server']);
     // Export Accounts (etc) to packages using this one.


### PR DESCRIPTION
meteor add okland:accounts-phone
 => Errors while adding packages:             
                                              
While selecting package versions:
error: Conflict: Constraint npm-bcrypt@=0.7.7 is not satisfied by npm-bcrypt 0.7.8_2.
Constraints on package "npm-bcrypt":
* npm-bcrypt@=0.7.8_2 <- accounts-password 1.1.1
* npm-bcrypt@=0.7.7 <- okland:accounts-phone 0.0.10